### PR TITLE
Exclude main branch (not master) commit msg checks

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
   push:
     branches-ignore:
-      - master
+      - main
 
 jobs:
   check-commit-message-style:


### PR DESCRIPTION
The trunk GitHub branch is main, not master, so it is the main branch
that we need to exclude from commit message style checks.