### PR TITLE
Create annual issue to update Ubuntu version

### DIFF
--- a/.github/DEPENDENCIES.md
+++ b/.github/DEPENDENCIES.md
@@ -1,0 +1,20 @@
+# Updating dependencies
+
+## Dependabot
+
+We use [GitHub Dependabot](https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically) 
+([bought by GitHub in 2019](https://dependabot.com/blog/hello-github/) and now 
+[baked into GitHub](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)) 
+to manage our dependencies.
+
+Whenever possible we let Dependabot update our dependencies automatically (by 
+[automatically creating a PR](https://docs.github.com/en/github/administering-a-repository/managing-pull-requests-for-dependency-updates#about-github-dependabot-pull-requests)
+for us to merge).
+
+Dependabot will automatically update our npm dependencies, along with
+[non-Docker dependencies in our GitHub Actions](https://github.blog/2020-06-25-dependabot-now-updates-your-actions-workflows/).
+
+
+## Ubuntu version in GitHub Actions
+
+[Ubuntu releases annually in April](https://wiki.ubuntu.com/Releases).  In 2020 the GitHub Actions team [supported the new version by mid June](https://github.com/actions/virtual-environments/issues/228#issuecomment-644065532), so we have [an issue automatically created on for 15th July each year](https://github.com/agilepathway/e2e-test-spectacle/pull/17) to prompt us to update. 

--- a/.github/ISSUE_TEMPLATE/scheduled/update-ubuntu-version-in-github-actions.md
+++ b/.github/ISSUE_TEMPLATE/scheduled/update-ubuntu-version-in-github-actions.md
@@ -1,0 +1,19 @@
+---
+name: Update Ubuntu version in GitHub Actions
+about: Stay up to date with Ubuntu
+title: Update Ubuntu version in GitHub Actions
+labels: ''
+assignees: ''
+
+---
+
+[Ubuntu releases annually in April](https://wiki.ubuntu.com/Releases).  
+
+In 2020 the GitHub Actions team [supported the April release for that year by mid June](https://github.com/actions/virtual-environments/issues/228#issuecomment-644065532), so this GitHub Issue gets automatically created annually each year on 15 July for us to do the update (as hopefully GitHub Actions will support the new version by then each year).  
+
+We can find out if we can update yet [here](https://docs.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources).  
+
+When we do the update to the new version it involves e.g. for 2021, simply replacing every case of `ubuntu-20.04` with `ubuntu-21.04`.
+
+- [ ] when we have updated and merged the change to the main branch, [this search](https://github.com/agilepathway/label-checker/search?q=20.04&unscoped_q=20.04) should return zero results (NB it may take 5 minutes before the search index will show the right results)
+- [ ] update this issue template so that it corresponds to the following year (e.g. in July 2021, replace all cases of `20.04` with `21.04`)

--- a/.github/workflows/schedule_ubuntu_annual_update_issue.yml
+++ b/.github/workflows/schedule_ubuntu_annual_update_issue.yml
@@ -1,0 +1,26 @@
+---
+name: Create issue annually to update Ubuntu
+on:  # yamllint disable-line rule:truthy
+  # Scheduled for 2am on 15th July every year
+  schedule:
+    - cron: '0 2 15 7 *'  # * is a special character in YAML so we have to quote this string
+
+jobs:
+  create_issue:
+    name: Create issue to update Ubuntu
+    runs-on: ubuntu-20.04
+    steps:
+
+      # Repo code checkout required if `template` is used
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - name: issue-bot
+        uses: imjohnbo/issue-bot@v2.3
+        with:
+          assignees: "johnboyes"
+          labels: "dependencies"
+          # assignees & labels in the template are overridden by the values specified in this action
+          template: ".github/ISSUE_TEMPLATE/scheduled/update-ubuntu-version-in-github-actions.md"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit ensures that we are prompted to update the Ubuntu version
used in GitHub Actions annually.