### PR TITLE
Update Chromium version on devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ ARG VARIANT=14
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
-ARG CHROMIUM_VERSION="90.0.4430.212-1~deb10u1"
+ARG CHROMIUM_VERSION="105.0.5195.102-1~deb11u1"
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
    && apt-get -y install --no-install-recommends chromium="${CHROMIUM_VERSION}" \
 # Clean up


### PR DESCRIPTION
Obtained the new version to update to by:

1. temporarily unpinning the Chromium version in the `Dockerfile`
2. rebuilding the devcontainer
3. running `apt-cache policy chromium` to see the new version
4. pinning that new version, in this commit