### PR TITLE
Add vscode autosave settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,7 @@
     "files.associations": {
         "*.spec": "gauge",
         "*.cpt": "gauge"
-    }
+    },
+    "files.autoSave": "afterDelay",
+    "files.autoSaveDelay": 500
 }


### PR DESCRIPTION
These settings automatically appeared after rebuilding the devcontainer,
so it looks like they are setup automatically by Gauge.