### PR TITLE
Make Dockerfile consistent with reference one

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
 
 # [Optional] Uncomment if you want to install more global node modules
-# RUN sudo -u node npm install -g <your-package-list-here>
+# RUN su node -c "npm install -g <your-package-list-here>"
 
 # Install gauge and gauge plugins
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
This commit tweaks our devcontainer Dockerfile very slightly, to make it
consistent with [the reference javascript devcontainer][1]

[1]: https://github.com/devcontainers/images/blob/main/src/javascript-node/.devcontainer/Dockerfile