### PR TITLE
Unpin commit checker version

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check
-        uses: mristin/opinionated-commit-message@v3.0.0
+        uses: mristin/opinionated-commit-message@master
         with:
           allow-one-liners: 'true'


### PR DESCRIPTION
It is not production-facing, so there is no major risk
in always using the latest version from `master`.